### PR TITLE
ESBUILD command

### DIFF
--- a/js/xo.js
+++ b/js/xo.js
@@ -1,3 +1,4 @@
+import 'regenerator-runtime/runtime'; // included for babel build 
 import ExoFormFactory from '../src/exo/ExoFormFactory';
 import ExoRouteModule from '../src/exo/ExoRouteModule';
 import ExoWizardRouteModule from '../src/exo/ExoWizardRouteModule';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@mvneerven/xo-js",
-  "version": "1.1.24",
+  "version": "1.1.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvneerven/xo-js",
-      "version": "1.1.24",
+      "version": "1.1.26",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.11.23",
+        "regenerator-runtime": "^0.13.7",
         "typescript": "^4.2.4"
       }
     },
@@ -22,6 +23,12 @@
       "bin": {
         "esbuild": "bin/esbuild"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "4.2.4",
@@ -42,6 +49,12 @@
       "version": "0.11.23",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
       "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
       "dev": true
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
   "homepage": "https://www.xo-js.dev",
   "scripts": {
     "dev": "esbuild js/xo.js --bundle --watch --outfile=dist/xo.js",
-    "build": "esbuild js/xo.js --bundle --minify --platform=node --target=node10.4 --outfile=dist/xo.min.js&&tsc"
+    "build": "esbuild js/xo.js --bundle --minify --platform=node --target=node12 --format=esm --outfile=dist/xo.min.js&&tsc"
   },
   "license": "MIT",
   "devDependencies": {
     "esbuild": "^0.11.23",
+    "regenerator-runtime": "^0.13.7",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
Set format to esm and added regenerator runtime again (seemed to be necessary...). Tested it with all ASF shared libraries and Vue project. Worked nicely. Didn't work immediately with jest, but with the usage of npm package cross-env, it worked without any hassle. Hopefully this was the last thing.